### PR TITLE
google-cloud-aiplatform 1.66.0 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -7,4 +7,4 @@ channels:
   - https://staging.continuum.io/prefect/fs/google-cloud-bigquery-feedstock/pr1/b60cd2a
   - https://staging.continuum.io/prefect/fs/db-dtypes-feedstock/pr2/858133a
   - https://staging.continuum.io/prefect/fs/google-cloud-resource-manager-feedstock/pr2/2111e8f
-  - https://staging.continuum.io/prefect/fs/grpc-google-iam-v1-feedstock/pr/dcf29b3
+  - https://staging.continuum.io/prefect/fs/grpc-google-iam-v1-feedstock/pr2/dcf29b3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,8 @@
+upload_channels:
+  - sfe1ed40
+
+channels:
+  - https://staging.continuum.io/prefect/fs/docstring_parser-feedstock/pr2/55a571c
+  - https://staging.continuum.io/prefect/fs/google-cloud-bigquery-storage-feedstock/pr1/d4bfa42
+  - https://staging.continuum.io/prefect/fs/google-cloud-bigquery-feedstock/pr1/b60cd2a
+  - https://staging.continuum.io/prefect/fs/db-dtypes-feedstock/pr2/858133a

--- a/abs.yaml
+++ b/abs.yaml
@@ -6,3 +6,5 @@ channels:
   - https://staging.continuum.io/prefect/fs/google-cloud-bigquery-storage-feedstock/pr1/d4bfa42
   - https://staging.continuum.io/prefect/fs/google-cloud-bigquery-feedstock/pr1/b60cd2a
   - https://staging.continuum.io/prefect/fs/db-dtypes-feedstock/pr2/858133a
+  - https://staging.continuum.io/prefect/fs/google-cloud-resource-manager-feedstock/pr2/2111e8f
+  - https://staging.continuum.io/prefect/fs/grpc-google-iam-v1-feedstock/pr/dcf29b3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,10 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/prefect/fs/docstring_parser-feedstock/pr2/55a571c
-  - https://staging.continuum.io/prefect/fs/google-cloud-bigquery-storage-feedstock/pr1/d4bfa42
-  - https://staging.continuum.io/prefect/fs/google-cloud-bigquery-feedstock/pr1/b60cd2a
-  - https://staging.continuum.io/prefect/fs/db-dtypes-feedstock/pr2/858133a
-  - https://staging.continuum.io/prefect/fs/google-cloud-resource-manager-feedstock/pr2/2111e8f
-  - https://staging.continuum.io/prefect/fs/grpc-google-iam-v1-feedstock/pr2/dcf29b3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -130,8 +130,8 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or TestGcsUtils" %}
 # results in "gs:////" instead of "gs://""
 {% set tests_to_skip = tests_to_skip + " or test_image_embedding_model_with_storage_url" %}
-# on py312 fails on self.assertEqual(stats.has_new_data_since_last_summarize(), True)
-{% set tests_to_skip = tests_to_skip + " or testSummarizeeWithoutTensorsOrBlobs" %}  # [py>311]
+# flaky fails on self.assertEqual(stats.has_new_data_since_last_summarize(), True)
+{% set tests_to_skip = tests_to_skip + " or testSummarizeeWithoutTensorsOrBlobs" %}
 # requires pyarrow which will cause conflicts
 {% set tests_to_skip = tests_to_skip + " or test_create_dataset_tabular_from_dataframe" %}
 # wrong positional index in a list, same items

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,13 +54,15 @@ requirements:
     - lit-nlp ==0.4.0
     - explainable-ai-sdk >=1.0.0
     # - pandas >=1.0.0
-    - pyarrow >=6.0.1
+    # - pyarrow >=6.0.1
     # pipelines
     - pyyaml >=5.3.1,<7
     # datasets
-    - pyarrow >=3.0.0,< 8.0dev  # [py<311]
-    - pyarrow >=10.0.1          # [py==311]
-    - pyarrow >=14.0.0          # [py>311]
+    #    these constraints are not satisfiable because a transient dependency
+    #    google-cloud-bigquery-storage 2.26.0 requires pyarrow >=0.15.0
+    # - pyarrow >=3.0.0,<8.0dev   # [py<311]
+    # - pyarrow >=10.0.1          # [py==311]
+    # - pyarrow >=14.0.0          # [py>311]
     # vizier
     - google-vizier >=0.1.6
     # prediction

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -131,6 +131,10 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_image_embedding_model_with_storage_url" %}
 # on py312 fails on self.assertEqual(stats.has_new_data_since_last_summarize(), True)
 {% set tests_to_skip = tests_to_skip + " or testSummarizeeWithoutTensorsOrBlobs" %}  # [py>311]
+# requires pyarrow which will cause conflicts
+{% set tests_to_skip = tests_to_skip + " or test_create_dataset_tabular_from_dataframe" %}
+# wrong positional index in a list, same items
+{% set tests_to_skip = tests_to_skip + " or test_get_experiment_df" %}
 
 # list test files to be ignored
 {% set tests_to_ignore = "" %}
@@ -195,6 +199,8 @@ test:
     - tests/unit
   commands:
     - pip check
+    # check that pip gets the correct version 
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     # tensorflow needed
     # - tb-gcp-uploader --help
     - pytest -vv tests/unit {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,81 @@ requirements:
     - shapely <3.0.0dev
     - docstring_parser <1
     - pydantic <3
+  run_constrained:
+    # profiler
+    - tensorboard-plugin-profile >=2.4.0,<3.0.0dev
+    - werkzeug >=2.0.0,<2.1.0dev
+    - tensorflow >=2.4.0,<3.0.0dev
+    # tensorboard
+    - tensorflow >=2.3.0,<3.0.0dev  # [py<312]
+    # metadata
+    - pandas >=1.0.0
+    - numpy >=1.15.0
+    # xai
+    # - tensorflow >=2.3.0,<3.0.0dev
+    # lit
+    # - tensorflow >=2.3.0,<3.0.0dev
+    # - pandas >=1.0.0
+    - lit-nlp ==0.4.0
+    - explainable-ai-sdk >=1.0.0
+    # - pandas >=1.0.0
+    - pyarrow >=6.0.1
+    # pipelines
+    - pyyaml >=5.3.1,<7
+    # datasets
+    - pyarrow >=3.0.0,< 8.0dev  # [py<311]
+    - pyarrow >=10.0.1          # [py==311]
+    - pyarrow >=14.0.0          # [py>311]
+    # vizier
+    - google-vizier >=0.1.6
+    # prediction
+    - docker >=5.0.3
+    - fastapi >=0.71.0,<=0.114.0
+    - httpx >=0.23.0,<0.25.0 # Optional dependency of fastapi
+    - starlette >=0.17.1
+    - uvicorn >=0.16.0
+    # endpoint
+    - requests >=2.28.1
+    # private_endpoints
+    - urllib3 >=1.21.1,<1.27
+    # - requests >= 2.28.1
+    # autologging
+    - mlflow >=1.27.0,<=2.1.1
+    # ray
+        # Cluster only supports 2.9.3 and 2.33.0. Keep 2.4.0 for our testing environment.
+        # Note that testing is submiting a job in a cluster with Ray 2.9.3 remotely.
+    - ray >=2.4,<=2.33.0,!= 2.5.*,!= 2.6.*,!= 2.7.*,!=2.8.*,!=2.9.0,!=2.9.1,!=2.9.2,!=2.10.*,!=2.11.*,!=2.12.*,!=2.13.*,!=2.14.*,!=2.15.*,!=2.16.*,!=2.17.*,!=2.18.*,!=2.19.*,!=2.20.*,!=2.21.*,!=2.22.*,!=2.23.*,!=2.24.*,!=2.25.*,!=2.26.*,!=2.27.*,!=2.28.*,!=2.29.*,!=2.30.*,!=2.31.*,!=2.32.*  # [py<311]
+        # To avoid  ImportError: cannot import name 'packaging' from 'pkg.resources'
+    - setuptools < 70.0.0
+        # Ray Data v2.4 in Python 3.11 is broken, but got fixed in Ray v2.5.
+    - ray >=2.5,<= 2.33.0  # [py==311]
+    - pandas >=1.0.0,<2.2.0
+    # - pyarrow >=6.0.1
+        # Workaround for https://github.com/ray-project/ray/issues/36990.
+        # TODO(b/295406381): Remove this pin when we drop support of ray<=2.5.
+    # - pydantic <2
+    # genai_requires
+    # - pydantic <3
+    # - docstring_parser <1
+    # reasoning_engine
+    - cloudpickle >=3.0,<4.0
+    - google-cloud-trace <2
+    - opentelemetry-sdk <2
+    - opentelemetry-exporter-gcp-trace <2
+    - pydantic >=2.6.3,<3
+    # evaluation
+    # - pandas >=1.0.0,<2.2.0
+    - tqdm >=4.23.0
+    # langchain
+    - langchain >=0.1.16,<0.3
+    - langchain-core <0.3
+    - langchain-google-vertexai <2
+    - openinference-instrumentation-langchain >=0.1.19,<0.2
+    - tenacity <=8.3
+    - orjson <=3.10.6
+    # tokenization
+    - sentencepiece >=0.2.0
+
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -111,6 +111,44 @@ requirements:
     # tokenization
     - sentencepiece >=0.2.0
 
+# list tests to be skipped
+{% set tests_to_skip = "" %}
+# test_admit for numerical approximation error
+{% set tests_to_skip = tests_to_skip + " test_admit" %}
+{% set tests_to_skip = tests_to_skip + " or test_function_call" %}
+{% set tests_to_skip = tests_to_skip + " or test_batch_predict_job_done_create" %}
+{% set tests_to_skip = tests_to_skip + " or test_function_response" %}
+# skip the whole class because it is not able to mock the GCS access correctly
+{% set tests_to_skip = tests_to_skip + " or TestGcsUtils" %}
+# results in "gs:////" instead of "gs://""
+{% set tests_to_skip = tests_to_skip + " or test_image_embedding_model_with_storage_url" %}
+
+# list test files to be ignored
+{% set tests_to_ignore = "" %}
+# noxfile.py#L205-L207
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/architecture" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/vertex_langchain" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/vertex_ray" %}
+# they require docker, some docker functionalities
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_prediction.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_docker_utils.py" %}
+# they require google-vizier unavailable
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_vizier.py" %}
+# they require explainable_ai_sdk
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_logdir_loader.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_explain_lit.py" %}
+# they require mlflow
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_autologging.py" %}
+# they require tensorboard
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_uploader.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_uploader_utils.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_cloud_profiler.py" %}
+# they require tensorflow
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_models.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_uploader_main.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_metadata_models.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_explain_saved_model_metadata_builder_tf1_test.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_explain_saved_model_metadata_builder_tf2_test.py" %}
 
 test:
   imports:
@@ -118,12 +156,35 @@ test:
     # vertex_ray is an extra and shouldn't be tested unless we want to add those extras
     # - vertex_ray
     - vertexai
-  commands:
-    - pip check
-    # missing dependency on absl-py
-    # - tb-gcp-uploader --help
   requires:
     - pip
+    - pytest
+    # noxfile.py#L56-L62
+    - mock
+    - pytest-asyncio
+    - pytest-xdist
+    # various dependencies according to tests need
+    - pandas
+    - tqdm
+    - scikit-learn
+    - sentencepiece
+    - nltk
+    - pyyaml
+    - absl-py
+    - pillow
+    - google-cloud-bigquery-storage
+    - fastapi
+    - werkzeug
+    - httpx
+    - ipython
+    - jinja2
+  source_files:
+    - tests/unit
+  commands:
+    - pip check
+    # tensorflow needed
+    # - tb-gcp-uploader --help
+    - pytest -vv tests/unit {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"
 
 about:
   home: https://cloud.google.com/vertex-ai/docs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -130,11 +130,6 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or TestGcsUtils" %}
 # results in "gs:////" instead of "gs://""
 {% set tests_to_skip = tests_to_skip + " or test_image_embedding_model_with_storage_url" %}
-# flaky fails
-{% set tests_to_skip = tests_to_skip + " or testSummarizeeWithoutTensorsOrBlobs" %}
-{% set tests_to_skip = tests_to_skip + " or testBlobTrackerNotUploaded" %}
-{% set tests_to_skip = tests_to_skip + " or testUploadedSummaryWithTensorsAndBlobs" %}
-{% set tests_to_skip = tests_to_skip + " or testHasNewDataSinceLastSummarizeReturnsTrueAfterNewBlob" %}
 # requires pyarrow which will cause conflicts
 {% set tests_to_skip = tests_to_skip + " or test_create_dataset_tabular_from_dataframe" %}
 # wrong positional index in a list, same items
@@ -172,6 +167,8 @@ requirements:
 # this requires directly google-cloud-bigquery-storage and if we add it in the test environment
 # will cause other conflicts
 {% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_featurestores.py" %}
+# flaky fails
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_upload_tracker.py" %}
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<38]
+  # skip s390x: many dependencies missing
+  skip: true  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - tb-gcp-uploader=google.cloud.aiplatform.tensorboard.uploader_main:run_main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "google-cloud-aiplatform" %}
-{% set version = "1.21.0" %}
+{% set version = "1.66.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,41 +7,62 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/google-cloud-aiplatform-{{ version }}.tar.gz
-  sha256: 3cd8fdc1b38e2a21552cbdacb338c4779a27c222bb1ea2481eb56b4fa844917b
+  sha256: e95a2b45087e0e2cbfed9ffaf3f10aa8ef3fa2e5642f067246181b5c7b9b2b04
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - tb-gcp-uploader=google.cloud.aiplatform.tensorboard.uploader_main:run_main
 
 requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
-    - google-api-core-grpc >=1.32.0,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*
-    - proto-plus >=1.22.0,<2.0.0dev
-    - protobuf >=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
-    - packaging >=14.3,<22.0.0dev
+    - google-api-core >=1.34.1,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*
+    - google-api-core-grpc
+    - proto-plus >=1.22.3,<2.0.0dev
+    - protobuf >=3.20.2,<6.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+    - packaging >=14.3
+    - google-auth >=2.14.1,<3.0.0dev
     - google-cloud-storage >=1.32.0,<3.0.0dev
-    - google-cloud-bigquery-core >=1.15.0,<4.0.0dev
+    - google-cloud-bigquery-core >=1.15.0,<4.0.0dev,!=3.20.0
     - google-cloud-resource-manager >=1.3.3,<3.0.0dev
-    - shapely <2.0.0
+    - shapely <3.0.0dev
+    - docstring_parser <1
+    - pydantic <3
 
 test:
   imports:
     - google
+    # vertex_ray is an extra and shouldn't be tested unless we want to add those extras
+    # - vertex_ray
+    - vertexai
   commands:
     - pip check
+    # missing dependency on absl-py
+    # - tb-gcp-uploader --help
   requires:
     - pip
 
 about:
-  home: https://github.com/googleapis/python-aiplatform
-  summary: Vertex AI API client library
+  home: https://cloud.google.com/vertex-ai/docs
   license: Apache-2.0
   license_file: LICENSE
-
+  license_family: Apache
+  summary: A Python SDK for Vertex AI, a fully managed, end-to-end platform for data science and machine learning.
+  description: |
+    Vertex AI: Google Vertex AI is an integrated suite of machine learning tools and services
+    for building and using ML models with AutoML or custom code. It offers both novices and
+    experts the best workbench for the entire machine learning development lifecycle.
+  doc_url: https://cloud.google.com/python/docs/reference/aiplatform/latest
+  dev_url: https://github.com/googleapis/python-aiplatform
+  
 extra:
   recipe-maintainers:
     - xylar

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,7 @@ requirements:
     - pyarrow >=10.0.1          # [py==311]
     - pyarrow >=14.0.0          # [py>311]
     # vizier
-     - google-vizier >=0.1.6
+    - google-vizier >=0.1.6
     # prediction
     # - docker >=5.0.3
     # - fastapi >=0.71.0,<=0.114.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -124,6 +124,8 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or TestGcsUtils" %}
 # results in "gs:////" instead of "gs://""
 {% set tests_to_skip = tests_to_skip + " or test_image_embedding_model_with_storage_url" %}
+# on py312 fails on self.assertEqual(stats.has_new_data_since_last_summarize(), True)
+{% set tests_to_skip = tests_to_skip + " or testSummarizeeWithoutTensorsOrBlobs" %}  # [py>311]
 
 # list test files to be ignored
 {% set tests_to_ignore = "" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -130,12 +130,18 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or TestGcsUtils" %}
 # results in "gs:////" instead of "gs://""
 {% set tests_to_skip = tests_to_skip + " or test_image_embedding_model_with_storage_url" %}
-# flaky fails on self.assertEqual(stats.has_new_data_since_last_summarize(), True)
+# flaky fails
 {% set tests_to_skip = tests_to_skip + " or testSummarizeeWithoutTensorsOrBlobs" %}
+{% set tests_to_skip = tests_to_skip + " or testBlobTrackerNotUploaded" %}
+{% set tests_to_skip = tests_to_skip + " or testUploadedSummaryWithTensorsAndBlobs" %}
+{% set tests_to_skip = tests_to_skip + " or testHasNewDataSinceLastSummarizeReturnsTrueAfterNewBlob" %}
 # requires pyarrow which will cause conflicts
 {% set tests_to_skip = tests_to_skip + " or test_create_dataset_tabular_from_dataframe" %}
 # wrong positional index in a list, same items
 {% set tests_to_skip = tests_to_skip + " or test_get_experiment_df" %}
+# write permission error on win
+{% set tests_to_skip = tests_to_skip + " or test_package_folder" %}  # [win]
+{% set tests_to_skip = tests_to_skip + " or test_package_file" %}  # [win]
 
 # list test files to be ignored
 {% set tests_to_ignore = "" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,14 +37,20 @@ requirements:
     - docstring_parser <1
     - pydantic <3
   run_constrained:
+    # There are a lot of extras for this package and they often use
+    # the same packages with different pinnings. Here follow an approximation
+    # with some of those commented out, and the more restrictive ones
+    # enabled. To allow an easier update of these constraints, I leave
+    # them there and commented out.
+    #
     # profiler
     - tensorboard-plugin-profile >=2.4.0,<3.0.0dev
     - werkzeug >=2.0.0,<2.1.0dev
     - tensorflow >=2.4.0,<3.0.0dev
     # tensorboard
-    - tensorflow >=2.3.0,<3.0.0dev  # [py<312]
+    # - tensorflow >=2.3.0,<3.0.0dev  # [py<312]
     # metadata
-    - pandas >=1.0.0
+    # - pandas >=1.0.0
     - numpy >=1.15.0
     # xai
     # - tensorflow >=2.3.0,<3.0.0dev
@@ -58,19 +64,18 @@ requirements:
     # pipelines
     - pyyaml >=5.3.1,<7
     # datasets
-    #    these constraints are not satisfiable because a transient dependency
-    #    google-cloud-bigquery-storage 2.26.0 requires pyarrow >=0.15.0
-    # - pyarrow >=3.0.0,<8.0dev   # [py<311]
-    # - pyarrow >=10.0.1          # [py==311]
-    # - pyarrow >=14.0.0          # [py>311]
+    - pyarrow >=3.0.0,<8.0dev   # [py<311]
+    - pyarrow >=10.0.1          # [py==311]
+    - pyarrow >=14.0.0          # [py>311]
     # vizier
-    - google-vizier >=0.1.6
+     - google-vizier >=0.1.6
     # prediction
-    - docker >=5.0.3
-    - fastapi >=0.71.0,<=0.114.0
-    - httpx >=0.23.0,<0.25.0 # Optional dependency of fastapi
-    - starlette >=0.17.1
-    - uvicorn >=0.16.0
+    # - docker >=5.0.3
+    # - fastapi >=0.71.0,<=0.114.0
+      # httpx is an optional dependency of fastapi
+    # - httpx >=0.23.0,<0.25.0 
+    # - starlette >=0.17.1
+    # - uvicorn >=0.16.0
     # endpoint
     - requests >=2.28.1
     # private_endpoints
@@ -153,6 +158,9 @@ requirements:
 {% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_metadata_models.py" %}
 {% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_explain_saved_model_metadata_builder_tf1_test.py" %}
 {% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_explain_saved_model_metadata_builder_tf2_test.py" %}
+# this requires directly google-cloud-bigquery-storage and if we add it in the test environment
+# will cause other conflicts
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/unit/aiplatform/test_featurestores.py" %}
 
 test:
   imports:
@@ -167,7 +175,9 @@ test:
     - mock
     - pytest-asyncio
     - pytest-xdist
-    # various dependencies according to tests need
+    # Various optional dependencies for tests.
+    # Unfortunately, some other of them cannot be added because being optional
+    # and with the many constraints present, they conflict with each other.
     - pandas
     - tqdm
     - scikit-learn
@@ -176,7 +186,6 @@ test:
     - pyyaml
     - absl-py
     - pillow
-    - google-cloud-bigquery-storage
     - fastapi
     - werkzeug
     - httpx


### PR DESCRIPTION
google-cloud-aiplatform 1.66.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4481]
- dev_url (pypi): https://github.com/googleapis/python-aiplatform/tree/v1.66.0
- conda-forge: https://github.com/conda-forge/google-cloud-aiplatform-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/google-cloud-aiplatform/1.66.0
- pypi inspector: https://inspector.pypi.io/project/google-cloud-aiplatform/1.66.0

### Depends on

- AnacondaRecipes/docstring_parser-feedstock#2
- AnacondaRecipes/google-cloud-bigquery-feedstock#1
    - AnacondaRecipes/google-cloud-bigquery-storage-feedstock/pull/1
    - AnacondaRecipes/db-dtypes-feedstock/pull/2
- AnacondaRecipes/google-cloud-resource-manager-feedstock#2
    - AnacondaRecipes/grpc-google-iam-v1-feedstock#2

### Explanation of changes:

- new feedstock
- a lot of run_constrained make this feedstock very restrictive in dependencies: you might notice that in the tests we can't use all of the dependencies (e.g. `tensorflow`). This might be a problem. The alternative is to remove all of the run_constrained (or leave the most important) and try, but even in this way the numerous dependencies raise easily conflicts
- tests are thousands, and take 30 min for each python version to run: I will take all of the eventual feedback from reviewers and apply it all at once.


[PKG-4481]: https://anaconda.atlassian.net/browse/PKG-4481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ